### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/Dinoshauer/pryvate.svg?branch=master)](https://travis-ci.org/Dinoshauer/pryvate)
 [![Coverage Status](https://coveralls.io/repos/Dinoshauer/pryvate/badge.svg?branch=master)](https://coveralls.io/r/Dinoshauer/pryvate?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/pryvate/badge/?version=latest)](https://readthedocs.org/projects/pryvate/?badge=latest)
-[![Latest Version](https://pypip.in/version/pryvate/badge.svg?style=flat)](https://pypi.python.org/pypi/pryvate/)
+[![Latest Version](https://img.shields.io/pypi/v/pryvate.svg?style=flat)](https://pypi.python.org/pypi/pryvate/)
 
 
 Pryvate


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pryvate))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pryvate`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.